### PR TITLE
Remove prefix requirement

### DIFF
--- a/.env.production.awesim
+++ b/.env.production.awesim
@@ -12,7 +12,7 @@ APP_VERSION='0.1.0prod'
 
 USERS_FROM_GROUP='bmishiny'
 SHARED_APPS_ROOT="/fs/project/PAS1429/apps"
-APP_DATASET_ROOT="/fs/project/PAS1429/shiny_input_data"
+APP_DATASET_ROOT="/fs/project/PAS1429/data"
 
 # DATABASE_URL is used to configure via Rails 4.2 support for this,
 # instead of using DATABASE_PATH in a customization of the db/config.yml

--- a/app/helpers/mappings_helper.rb
+++ b/app/helpers/mappings_helper.rb
@@ -21,11 +21,11 @@ module MappingsHelper
 
   # Get a list of the various Shiny apps
   def app_list
-    Dir.glob( Configuration.shared_apps_root.join('bc_shiny_*')).sort.map{|path| Pathname.new(path)}
+    Configuration.shared_apps_root.children.select(&:directory?).sort
   end
 
   def app_list_help
-    "App list is built from apps in #{Configuration.shared_apps_root.to_s} with the directory name starting with 'bc_shiny_'"
+    "App list is built from apps in #{Configuration.shared_apps_root.to_s} that are directories."
   end
 
 


### PR DESCRIPTION
This caused problems for Venkat. We switch to assuming the only apps they deal with right now are shiny apps.